### PR TITLE
Make sample code indent consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,8 +447,8 @@ If you do not have an account then you can
    indicate that he wants insurance:</p>
 
    <pre>&lt;label&gt;
- &lt;input type="checkbox" onchange="sessionStorage.insurance = checked ? 'true' : ''"&gt;
-I want insurance on this trip.
+  &lt;input type="checkbox" onchange="sessionStorage.insurance = checked ? 'true' : ''"&gt;
+  I want insurance on this trip.
 &lt;/label&gt;</pre>
 
    <p>A later page could then check, from script, whether the user had


### PR DESCRIPTION
The latest Editor's Draft also made some improvement at
http://dev.w3.org/cvsweb/html5/webstorage/Overview.html.diff?r1=1.225;r2=1.226
but it only touched the text line.

This will make the 2 samples in the Introduction section get the same
indentation. Except this minor indent issue, this spec looks good to me.
